### PR TITLE
Improved update_attributes and flag setting

### DIFF
--- a/apply-pax-flags.c
+++ b/apply-pax-flags.c
@@ -3,6 +3,5 @@
 #include "flags.h"
 
 int main(void) {
-    update_attributes();
-    return EXIT_SUCCESS;
+    return update_attributes() < 0 ? 1 : 0;
 }

--- a/flags.c
+++ b/flags.c
@@ -3,37 +3,44 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <err.h>
 #include <sys/xattr.h>
 
 #include "flags.h"
 
-static void apply(const char *flags, size_t flags_len, const char *path) {
-    if (setxattr(path, "user.pax.flags", flags, flags_len, 0) == -1) {
-        if (errno != ENOENT) {
-            fprintf(stderr, "could not apply attributes to %s: %m\n", path);
+ssize_t set_pax_flags(const char *flags, size_t flags_len, const char *path) {
+    for (size_t i = 0; i < flags_len; i++) {
+        int flag = tolower(flags[i]);
+        if (!strchr(PAX_FLAGS, flag)) {
+            errno = EINVAL;
+            return -1;
         }
     }
+
+    return setxattr(path, "user.pax.flags", flags, flags_len, 0);
 }
 
-static void line_ignored(size_t n, const char *line) {
-    fprintf(stderr, "ignored invalid line %zu in /etc/paxd.conf: %s", n, line);
+ssize_t get_pax_flags(char *flags, size_t flags_len, const char *path) {
+    return getxattr(path, "user.pax.flags", flags, flags_len);
 }
 
-void update_attributes(void) {
+int update_attributes(void) {
     FILE *conf = fopen("/etc/paxd.conf", "r");
     if (!conf) {
-        perror("could not open /etc/paxd.conf");
-        return;
+        warn("could not open /etc/paxd.conf");
+        return -1;
     }
 
     char *line = NULL;
     size_t line_len = 0;
+    int rc = 0;
 
     for (size_t n = 1;; n++) {
         ssize_t bytes_read = getline(&line, &line_len, conf);
         if (bytes_read == -1) {
             if (ferror(conf)) {
-                perror("failed to read line from /etc/paxd.conf");
+                warn("failed to read line from /etc/paxd.conf");
+                rc = -1;
                 break;
             } else {
                 break;
@@ -44,36 +51,36 @@ void update_attributes(void) {
             continue; // ignore empty lines and comments
         }
 
-        const char *flags = line + strspn(line, " \t"); // skip initial whitespace
-
-        const char *split = flags + strcspn(flags, " \t"); // find the end of the specified flags
-        if (*split == '\0') {
-            line_ignored(n, line);
-            break;
-        }
-
-        const char *valid = "pemrs";
-        for (const char *flag = flags; flag < split; flag++) {
-            if (!strchr(valid, tolower(*flag))) {
-                line_ignored(n, line);
-                break;
-            }
-        }
-
-        const char *path = split + strspn(split, " \t"); // find the start of the path
-        if (*path != '/') {
-            line_ignored(n, line);
-            break;
-        }
-
         if (line[bytes_read - 1] == '\n') {
             line[bytes_read - 1] = '\0';
         }
 
+        char *flags = line + strspn(line, " \t"); // skip initial whitespace
+
+        const char *split = flags + strcspn(flags, " \t"); // find the end of the specified flags
+        const char *path = split + strspn(split, " \t"); // find the start of the path
+
+        if (*split == '\0' || *path != '/') {
+            warnx("line %zd: ignoring invalid line: %s", n, flags);
+            rc = -1;
+            break;
+        }
+
         size_t flags_len = (size_t)(split - flags);
-        apply(flags, flags_len, path);
+        flags[flags_len] = 0;
+
+        if (set_pax_flags(flags, flags_len, path) < 0) {
+            if (errno == EINVAL) {
+                warnx("line %zd: invalid pax flags: %s", n, flags);
+                rc = -1;
+            } else if (errno != ENOENT) {
+                warn("failed to set pax flags on %s", path);
+                rc = -1;
+            }
+        }
     }
 
     free(line);
     fclose(conf);
+    return rc;
 }

--- a/flags.h
+++ b/flags.h
@@ -1,6 +1,11 @@
 #ifndef FLAGS_H
 #define FLAGS_H
 
-void update_attributes(void);
+static const char PAX_FLAGS[] = "pemrs";
+#define PAX_LEN (sizeof(PAX_FLAGS) - 1)
+
+int update_attributes(void);
+ssize_t set_pax_flags(const char *flags, size_t flags_len, const char *path);
+ssize_t get_pax_flags(char *flags, size_t flags_len, const char *path);
 
 #endif


### PR DESCRIPTION
Curious to see if you'd approve of this work before I go ahead with `getpax`/`setpax`. This sets the foundation down with a few improvements to `update_attributes`.
- renamed apply to set_pax_flags and introduced get_pax_flags
- moved flag validation into set_pax_flags so it can be reused
- reorganized and condensed logic in update_attributes
- dropped line_ignored for warnx
- update_attributes now returns an exit status
