### PR TITLE
PAX_RANDMMAP needs to be disabled for convert, otherwise convert will…

### DIFF
--- a/paxd.conf
+++ b/paxd.conf
@@ -288,17 +288,17 @@ em /usr/lib/kde4/libexec/ktp-text-ui
 em /usr/lib/kscreenlocker_greet
 
 # imagemagick
-em /usr/bin/animate
-em /usr/bin/compare
-em /usr/bin/composite
-em /usr/bin/conjure
-em /usr/bin/convert
-em /usr/bin/display
-em /usr/bin/identify
-em /usr/bin/import
-em /usr/bin/mogrify
-em /usr/bin/montage
-em /usr/bin/stream
+em  /usr/bin/animate
+em  /usr/bin/compare
+em  /usr/bin/composite
+em  /usr/bin/conjure
+emr /usr/bin/convert
+em  /usr/bin/display
+em  /usr/bin/identify
+em  /usr/bin/import
+em  /usr/bin/mogrify
+em  /usr/bin/montage
+em  /usr/bin/stream
 
 # polkit
 em /usr/lib/polkit-1/polkitd


### PR DESCRIPTION
… max out the CPU in an infinite loop. See 'convert pic.png -blur 0x3 picnew.png'
