### PR TITLE
Add a julia exception

### DIFF
--- a/paxd.conf
+++ b/paxd.conf
@@ -473,3 +473,7 @@ em /opt/teamviewer/tv_bin/wine/bin/wine-preloader
 em /usr/bin/spotify
 em /usr/share/spotify/spotify
 em /usr/share/spotify/spotify-client/Data/SpotifyHelper
+
+# julia
+em /usr/bin/julia
+em /usr/bin/julia-debug


### PR DESCRIPTION
It's a JITed language so it needs RWX memory.
