### PR TITLE
Add lrzip to paxd.conf

### DIFF
--- a/paxd.conf
+++ b/paxd.conf
@@ -54,6 +54,7 @@ em  /usr/bin/liferea
 em  /usr/bin/lli
 em  /usr/bin/love
 em  /usr/bin/love08
+m   /usr/bin/lrzip
 emr /usr/bin/luajit
 E   /usr/bin/make
 em  /usr/bin/minitube


### PR DESCRIPTION
ZPAQ mode of lrzip needs mprotect disabled to be usable.
