### PR TITLE
added image viewers and grep

### DIFF
--- a/paxd.conf
+++ b/paxd.conf
@@ -46,6 +46,7 @@ em  /usr/bin/glxinfo
 em  /usr/bin/glxspheres
 em  /usr/bin/gnucash
 em  /usr/bin/goldendict
+em  /usr/bin/grep
 em  /usr/bin/HandBrakeCLI
 em  /usr/bin/hhvm
 em  /usr/bin/inkscape
@@ -62,8 +63,10 @@ em  /usr/bin/mono-sgen
 em  /usr/bin/mplayer
 em  /usr/bin/mumble
 em  /usr/bin/node
+em  /usr/bin/nomacs
 em  /usr/bin/nvim
 em  /usr/bin/obex-data-server
+em  /usr/bin/phototonic
 em  /usr/bin/quassel
 em  /usr/bin/quasselcore
 em  /usr/bin/racket


### PR DESCRIPTION
grep is added because it triggers multiple warnings when using pacaur. As mentioned in issue #66.
