### PR TITLE
Add Vivaldi in the browsers list

### DIFF
--- a/paxd.conf
+++ b/paxd.conf
@@ -467,6 +467,7 @@ em   /usr/lib/chromium/chromium
 pems /usr/lib/chromium/nacl_helper
 em   /usr/lib/opera/opera
 em   /usr/lib/opera/pluginwrapper/operapluginwrapper-native
+em   /opt/vivaldi/vivaldi-bin
 
 # wine
 pemrs /usr/bin/wine-preloader


### PR DESCRIPTION
Vivaldi, which is a Chromium based browser, needs those flags too.
So, I'm proposing that change.

As I'm not familiar with PaX, if there are other location to apply that kind of changes, don't hesitate to point me to them :)
